### PR TITLE
[1 of 3] Add GitHub Actions workflow to run unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: tests
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - run: python -m unittest


### PR DESCRIPTION
Before automating package builds, automate unit tests so that pull request and merges display test pass/fail status.