### PR TITLE
Add homepage, authorship and license metadata to package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,10 @@
 [metadata]
 name = octrees
 version = attr: octrees.VERSION
+url = https://github.com/jcranch/octrees/
+author = James Cranch
+author-email = j.d.cranch@sheffield.ac.uk
+license =  GPL-2.0-or-later
 description = a Python implementation of the octree data structure and supporting algorithms
 long_description = file: README.md
 classifiers =


### PR DESCRIPTION
This fills in all except one of the fields in the `PKG-INFO` file that is generated when the package is built.

The remaining field is `Platform` and currently appears as: `Platform: UNKNOWN` (the default).

I don't yet know what to set that to for a pure-Python package.